### PR TITLE
Add IconSymbol tests

### DIFF
--- a/components/__tests__/IconSymbol-test.tsx
+++ b/components/__tests__/IconSymbol-test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import renderer from 'react-test-renderer';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
+
+import { IconSymbol } from '../ui/IconSymbol';
+
+jest.mock('@expo/vector-icons/MaterialIcons', () => jest.fn(() => null));
+
+describe('IconSymbol', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const cases: Array<[Parameters<typeof IconSymbol>[0]['name'], string]> = [
+    ['house.fill', 'home'],
+    ['paperplane.fill', 'send'],
+    ['chevron.left.forwardslash.chevron.right', 'code'],
+    ['chevron.right', 'chevron-right'],
+  ];
+
+  it.each(cases)('maps %s to %s', (input, expected) => {
+    renderer.create(<IconSymbol name={input} color="red" />);
+    expect(MaterialIcons).toHaveBeenCalledWith(
+      expect.objectContaining({ name: expected }),
+      {}
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- test IconSymbol icon name mapping to MaterialIcons

## Testing
- `npx jest components/__tests__/IconSymbol-test.tsx` *(fails: `jest` not found)*