### PR TITLE
Remove unused WidgetCard styles

### DIFF
--- a/components/widgets/WidgetCard.tsx
+++ b/components/widgets/WidgetCard.tsx
@@ -284,18 +284,6 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     color: '#64748B',
   },
-  // Remove unused styles
-  thumbnailContent: {
-    justifyContent: 'center',
-    alignItems: 'center',
-    width: '100%',
-  },
-  thumbnailText: {
-    fontSize: 14,
-    fontWeight: '600',
-    color: '#334155',
-    textAlign: 'center',
-  },
   thumbnailHeader: {
     marginBottom: 0,
     paddingVertical: 0,


### PR DESCRIPTION
## Summary
- clean up `WidgetCard` styles

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: expo not found)*